### PR TITLE
Fix TLS protocol assignment in SoftEther installer script

### DIFF
--- a/softether-vpn-client/chocolateyInstall.ps1
+++ b/softether-vpn-client/chocolateyInstall.ps1
@@ -55,8 +55,7 @@ Write-Host "Downloading VPN Gate SoftEther client build $($zipInfo.Build) from $
 
 try {
   # Ensure TLS 1.2 support in older environments
-  [System.Net.ServicePointManager]::SecurityProtocol = \
-    [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 } catch {
   Write-Warning 'Unable to set TLS 1.2 on this platform. Download may fail if the host requires it.'
 }


### PR DESCRIPTION
## Summary
- remove invalid line continuation from TLS protocol assignment to prevent runtime parse errors during install

## Testing
- not run (not available in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694caccaa9ac8321ab6ca3ef457b5918)